### PR TITLE
Show asset locations in geofence, location and dispatching tabs.

### DIFF
--- a/Frontend/src/app/assets/asset-editor/asset-editor.component.ts
+++ b/Frontend/src/app/assets/asset-editor/asset-editor.component.ts
@@ -49,7 +49,6 @@ export class AssetEditorComponent implements OnInit, OnDestroy {
   }
 
   submit() {
-
     if (this.asset.assetType === AssetType.Truck) {
       this.asset.assetProperties = this.assetProperties;
     }

--- a/Frontend/src/app/assets/asset-list/asset-list.component.ts
+++ b/Frontend/src/app/assets/asset-list/asset-list.component.ts
@@ -38,6 +38,7 @@ export class AssetListComponent implements OnInit, OnDestroy {
   private selectedDateRange: DateRange;
   private lastCalledFunction: (asset: Asset, filterSelected: Boolean) => void;
   private subscription: Subscription;
+  private isDrawing = false;
   private isAlive: boolean;
   private assetsList: Asset[];
 
@@ -102,15 +103,7 @@ export class AssetListComponent implements OnInit, OnDestroy {
     this.unsubscribe();
     this.subscription = this.assetService.getLatestPoints()
       .subscribe(points => {
-        const mappedAssets = new Array<[Asset, TrackingPoint]>();
-
-        for (const key of Object.keys(points)) {
-          const value = points[key];
-          const asset = this.assetsList.find(val => val.id === key);
-          mappedAssets.push([asset, value]);
-        }
-
-        this.mapsService.showAssetsPositions(mappedAssets);
+        this.mapsService.showAssetsPositions(points);
 
         if (this.selectedAsset && !points[this.selectedAsset.id]) {
           this.toasterService.pop('error', '', 'Can\'t find position of ' + this.selectedAsset.id);
@@ -142,6 +135,7 @@ export class AssetListComponent implements OnInit, OnDestroy {
 
   selectTrip(trip): void {
     this.mapsService.showTrip(trip);
+    this.isDrawing = true;
   }
 
   timeFilterChange(range) {
@@ -154,6 +148,10 @@ export class AssetListComponent implements OnInit, OnDestroy {
   private unsubscribe() {
     if (this.subscription && !this.subscription.closed) {
       this.subscription.unsubscribe();
+    }
+    if (this.isDrawing) {
+      this.mapsService.endCurrentDraw();
+      this.isDrawing = false;
     }
   }
 

--- a/Frontend/src/app/dispatching/dispatching-editor/dispatching-editor.component.ts
+++ b/Frontend/src/app/dispatching/dispatching-editor/dispatching-editor.component.ts
@@ -20,7 +20,8 @@ import {
   DispatchingParameters,
   OptimizeValue,
   RouteAttributes,
-  TimeType } from '../dispatching-parameters';
+  TimeType
+} from '../dispatching-parameters';
 
 import {
   AvoidOptions,
@@ -67,8 +68,7 @@ export class DispatchingEditorComponent implements OnInit, OnDestroy {
   showHazardPermitList: boolean;
   showResultsList: boolean;
 
-  private resultsSubscription: Subscription;
-  private assetsSubscription: Subscription;
+  private isAlive: boolean;
 
   constructor(
     private assetService: AssetService,
@@ -81,38 +81,40 @@ export class DispatchingEditorComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.resultsSubscription = this.mapsService.getDispatchingPinsResult()
+    this.isAlive = true;
+    this.mapsService.getDispatchingPinsResult()
+      .takeWhile(() => this.isAlive)
       .subscribe(result => {
         if (result.length) {
-        this.pinsAdded = result;
+          this.pinsAdded = result;
         }
       });
 
-    this.assetsSubscription = this.assetService.getAssets()
+    this.assetService.getAssets()
+      .takeWhile(() => this.isAlive)
       .subscribe(assets => {
         if (!this.assets && assets.length) {
           this.assets = assets;
         }
       });
+
+    this.assetService.getLatestPoints()
+      .takeWhile(() => this.isAlive)
+      .subscribe(points => {
+        this.mapsService.showAssetsPositions(points, true);
+      });
   }
 
   ngOnDestroy() {
-    this.mapsService.endDispatchingPinsDraw();
-
-    if (this.resultsSubscription) {
-      this.resultsSubscription.unsubscribe();
-    }
-
-    if (this.assetsSubscription) {
-      this.assetsSubscription.unsubscribe();
-    }
+    this.mapsService.endCurrentDraw();
+    this.isAlive = false;
   }
 
   openDialog() {
     this.dialogService.showLocationsDialog()
       .subscribe(location => {
         if (location) {
-          location.name = this.locationService.generateLocationName(location);
+          location.name = this.locationService.normalizeLocationName(location);
           this.pinsAdded.push(location);
           this.mapsService.resetDispatchingDraw(this.pinsAdded);
         }
@@ -179,7 +181,7 @@ export class DispatchingEditorComponent implements OnInit, OnDestroy {
 
   private setAllDispatchingParameters() {
     this.dispatchingParameters.avoid = this.AvoidOptions
-    .filter(option => option.isChecked).map(option => option.value);
+      .filter(option => option.isChecked).map(option => option.value);
 
     this.dispatchingParameters.hazardousMaterials = this.HazardMaterialOptions
       .filter(option => option.isChecked).map(option => option.value);

--- a/Frontend/src/app/dispatching/location-dialog/location-dialog.component.ts
+++ b/Frontend/src/app/dispatching/location-dialog/location-dialog.component.ts
@@ -39,6 +39,6 @@ export class LocationDialogComponent implements OnInit, OnDestroy {
   }
 
   getLocationName(location: Location) {
-    return this.locationService.generateLocationName(location);
+    return this.locationService.normalizeLocationName(location);
   }
 }

--- a/Frontend/src/app/geofences/geofence-editor/geofence-editor.component.ts
+++ b/Frontend/src/app/geofences/geofence-editor/geofence-editor.component.ts
@@ -91,7 +91,7 @@ export class GeofenceEditorComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.mapsService.endGeofenceDraw();
+    this.mapsService.endCurrentDraw();
 
     if (this.routeSubscription) {
       this.routeSubscription.unsubscribe();
@@ -159,7 +159,7 @@ export class GeofenceEditorComponent implements OnInit, OnDestroy {
   }
 
   clearPoints() {
-    this.mapsService.endGeofenceDraw();
+    this.mapsService.endCurrentDraw();
 
     if (this.geofence.areaType === AreaType.Polygon) {
       this.geofence.fencePolygon = new Array<Point>();

--- a/Frontend/src/app/geofences/geofence-list/geofence-list.component.ts
+++ b/Frontend/src/app/geofences/geofence-list/geofence-list.component.ts
@@ -3,6 +3,9 @@ import { Observable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
 
 import { Geofence, FenceType } from '../../shared/geofence';
+import { Asset } from '../../assets/asset';
+import { TrackingPoint } from '../../shared/tracking-point';
+import { AssetService } from '../../assets/asset.service';
 import { GeofenceService } from '../geofence.service';
 import { MapsService } from '../../maps/maps.service';
 
@@ -12,27 +15,37 @@ import { MapsService } from '../../maps/maps.service';
   styleUrls: ['./geofence-list.component.css']
 })
 export class GeofenceListComponent implements OnInit, OnDestroy {
+  geofences: Observable<Geofence[]>;
   retrievedGeofences: Geofence[];
   selectedGeofence: Geofence;
-  filter: string;
-  geofences: Observable<Geofence[]>;
-  geofencesSubscription: Subscription;
   FenceType = FenceType;
+  filter: string;
+  private isAlive: boolean;
 
-  constructor(private geofenceService: GeofenceService, private mapsService: MapsService) { }
+  constructor(
+    private geofenceService: GeofenceService,
+    private assetService: AssetService,
+    private mapsService: MapsService) { }
 
   ngOnInit() {
+    this.isAlive = true;
     this.geofences = this.geofenceService.getAll();
-    this.geofencesSubscription = this.geofences.subscribe(geofences => {
-      this.mapsService.showGeofences(geofences);
-      this.retrievedGeofences = geofences;
-    });
+    this.geofences
+      .takeWhile(() => this.isAlive)
+      .subscribe(geofences => {
+        this.mapsService.showGeofences(geofences);
+        this.retrievedGeofences = geofences;
+      });
+
+    this.assetService.getLatestPoints()
+      .takeWhile(() => this.isAlive)
+      .subscribe(points => {
+        this.mapsService.showAssetsPositions(points, true);
+      });
   }
 
   ngOnDestroy(): void {
-    if (this.geofencesSubscription && !this.geofencesSubscription.closed) {
-      this.geofencesSubscription.unsubscribe();
-    }
+    this.isAlive = false;
   }
 
   showGeofence(geofence: Geofence) {

--- a/Frontend/src/app/locations/location.service.ts
+++ b/Frontend/src/app/locations/location.service.ts
@@ -7,7 +7,6 @@ import { Point } from '../shared/point';
 
 @Injectable()
 export class LocationService {
-
   constructor(private dataSevrice: DataService) { }
 
   addLocation(location: Location): Observable<void> {
@@ -27,23 +26,14 @@ export class LocationService {
   }
 
   getLocationAssetsCount(location: Location): Observable<Map<string, number>> {
-    return this.dataSevrice.getSingleNoCache<Map<string, number>>( `locations/${location.id}/assetsCount`);
+    return this.dataSevrice.getSingleNoCache<Map<string, number>>(`locations/${location.id}/assetsCount`);
   }
 
-  getLocationMap(locations: Location[]): Map<string, Location> {
-      const map: Map<string, Location> = new Map();
-      for (const location of locations) {
-        const locationName = this.generateLocationName(location);
-        map.set(locationName, location);
-      }
-      return map;
+  normalizeLocationName(location: Location) {
+    if (location.name === 'Auto-Generated Location') {
+      return 'Location ' + location.id;
+    } else {
+      return location.name;
     }
-
-    generateLocationName(location: Location) {
-      if (location.name === 'Auto-Generated Location') {
-        return 'Location ' + location.id;
-      } else {
-        return location.name;
-      }
-    }
+  }
 }

--- a/Frontend/src/app/maps/bing-maps.service.ts
+++ b/Frontend/src/app/maps/bing-maps.service.ts
@@ -153,27 +153,8 @@ export class BingMapsService {
 
     private timeConverter(timestamp) {
         const a = new Date(timestamp);
-        const months = [
-            'Jan',
-            'Feb',
-            'Mar',
-            'Apr',
-            'May',
-            'Jun',
-            'Jul',
-            'Aug',
-            'Sep',
-            'Oct',
-            'Nov',
-            'Dec'
-        ];
-        const year = a.getFullYear();
-        const month = months[a.getMonth()];
-        const day = a.getDate();
-        const hour = a.getHours();
-        const min = a.getMinutes();
-        const sec = a.getSeconds();
-        return `${day} ${month} ${hour}:${min}:${sec}`;
+        return a.toLocaleString('en-US',
+            { month: 'short', day: 'numeric', hour: 'numeric', minute: 'numeric', second: 'numeric' });
     }
 
     private resetMap() {

--- a/Frontend/src/app/maps/bing-maps.service.ts
+++ b/Frontend/src/app/maps/bing-maps.service.ts
@@ -14,26 +14,32 @@ import { TripService } from '../core/trip.service';
 import { LocationService } from '../locations/location.service';
 
 import 'rxjs/add/operator/map';
+import { TripLeg } from '../shared/trip-leg';
 
 @Injectable()
 export class BingMapsService {
-    static colors = ['#56A6B6', '#464E50', '#56B691', '#BF8B8A', '#E95794'];
-    static tripColors = ['#000CCC', '#CC0200', '#73CC15', '#00EAFF'];
-    private loadPromise: Promise<void>;
-    private map: Microsoft.Maps.Map;
-    private infobox: Microsoft.Maps.Infobox;
-    private searchManager: Microsoft.Maps.Search.SearchManager;
-    private trip: Trip;
+    private readonly genericColors = ['#56A6B6', '#464E50', '#56B691', '#BF8B8A', '#E95794'];
+    private readonly tripColors = ['#000CCC', '#CC0200', '#73CC15', '#00EAFF'];
     private readonly yellowSpeed = 4.4;
     private readonly greenSpeed = 13.4;
+    private readonly geofenceGreenBlue = 'rgba(86,182,145,0.4)';
+    private readonly geofencePink = 'rgba(233,87,148,0.4)';
+
+    private map: Microsoft.Maps.Map;
+    private loadPromise: Promise<void>;
+    private searchManager: Microsoft.Maps.Search.SearchManager;
     private drawHandlerId;
-    private previousHighlightPoint: Microsoft.Maps.Pushpin;
 
-    constructor(
-        private tripService: TripService,
-        private locationService: LocationService
-    ) { }
+    private geofencesLayer: Microsoft.Maps.Layer;
+    private assetsLayer: Microsoft.Maps.Layer;
+    private devicesLayer: Microsoft.Maps.Layer;
+    private pointsLayer: Microsoft.Maps.Layer;
+    private tripsLayer: Microsoft.Maps.Layer;
+    private locationsLayer: Microsoft.Maps.Layer;
 
+    constructor(private tripService: TripService) { }
+
+    /* GENERIC FUNCTIONS */
     init(element: HTMLElement, options: Microsoft.Maps.IMapLoadOptions): void {
         this.load().then(() => {
             this.map = new Microsoft.Maps.Map(element, options);
@@ -44,642 +50,39 @@ export class BingMapsService {
                 });
             }
 
-            Microsoft.Maps.Events.addHandler(this.map, 'click', e => {
-                if (this.trip) {
-                    const event = e as Microsoft.Maps.IMouseEventArgs;
-                    this.tripService.getPoints(
-                        this.trip.id,
-                        event.location.latitude,
-                        event.location.longitude
-                    ).subscribe(points => {
-                        for (const point of points) {
-                            let pinColor;
-                            if (point.speed >= this.greenSpeed) {
-                                pinColor = 'green';
-                            } else if (
-                                point.speed < this.greenSpeed &&
-                                point.speed >= this.yellowSpeed
-                            ) {
-                                pinColor = 'yellow';
-                            } else {
-                                pinColor = 'red';
-                            }
-                            const pp = this.createPushPin(
-                                point,
-                                this.trip.id,
-                                pinColor,
-                                this.timeConverter(point.time),
-                                `speed: ${Math.round(
-                                    point.speed * 3.6
-                                )} km/hr, accuracy: ${point.accuracy}`
-                            );
-                            this.map.entities.add(pp);
-                        }
-                    });
-                }
-            });
+            this.geofencesLayer = new Microsoft.Maps.Layer('geofencesLayer');
+            this.assetsLayer = new Microsoft.Maps.Layer('assetsLayer');
+            this.devicesLayer = new Microsoft.Maps.Layer('devicesLayer');
+            this.tripsLayer = new Microsoft.Maps.Layer('tripsLayer');
+            this.locationsLayer = new Microsoft.Maps.Layer('locationsLayer');
+            this.pointsLayer = new Microsoft.Maps.Layer('pointsLayer');
+
+            this.map.layers.insert(this.geofencesLayer);
+            this.map.layers.insert(this.assetsLayer);
+            this.map.layers.insert(this.devicesLayer);
+            this.map.layers.insert(this.tripsLayer);
+            this.map.layers.insert(this.locationsLayer);
+            this.map.layers.insert(this.pointsLayer);
         });
     }
 
-    showGeofences(geofences: Geofence[]): void {
-        this.load().then(() => {
-            this.clear();
-
-            const locations = new Array<Microsoft.Maps.Location>();
-
-            // tslint:disable-next-line:forin
-            for (const g in geofences) {
-                const geofence = geofences[g];
-
-                locations.splice(0, locations.length);
-                locations.push.apply(locations,
-                    this.drawGeofencePolygon(geofence, 'rgba(86,182,145,0.4)', BingMapsService.colors[0]));
-            }
-
-            this.centerMapCentroid(locations);
-        });
-    }
-
-    showGeofence(geofence: Geofence): void {
-        this.load().then(() => {
-            this.clear();
-            const polygonLocations = this.drawGeofencePolygon(geofence, 'rgba(86,182,145,0.4)', BingMapsService.colors[0]);
-            this.centerMapCentroid(polygonLocations);
-        });
-    }
-
-    drawCircularGeofence(subject: Subject<Point>, initialCenter: Point, initialRadius: number, radius: Observable<number>) {
-        this.load().then(() => {
-            const currentCenter = initialCenter;
-            let currentRadius = initialRadius;
-            this.clear();
-
-            if (initialCenter && initialCenter.latitude && initialCenter.longitude && initialRadius) {
-                const polygon = new Microsoft.Maps.Polygon(
-                    this.getCirclePolygon(currentCenter, currentRadius),
-                    {
-                        fillColor: 'rgba(86,182,145,0.4)',
-                        strokeColor: BingMapsService.colors[0]
-                    });
-
-                const pushpin = new Microsoft.Maps.Pushpin(new Microsoft.Maps.Location(currentCenter.latitude, currentCenter.longitude),
-                    {
-                        color: BingMapsService.colors[0],
-                        icon: '/assets/images/circular-geofence-center-green.svg',
-                        anchor: new Microsoft.Maps.Point(12, 12)
-                    });
-
-                this.map.entities.push(pushpin);
-                this.map.entities.push(polygon);
-                this.centerMap([currentCenter]);
-            }
-
-            const onCircularGeofenceChanged = () => {
-                this.clear();
-                const polygon = new Microsoft.Maps.Polygon(
-                    this.getCirclePolygon(currentCenter, currentRadius),
-                    {
-                        fillColor: 'rgba(233,87,148,0.4)',
-                        strokeColor: BingMapsService.colors[4]
-                    }
-                );
-
-                const pushpin = new Microsoft.Maps.Pushpin(
-                    new Microsoft.Maps.Location(currentCenter.latitude, currentCenter.longitude),
-                    {
-                        icon: '/assets/images/circular-geofence-center-pink.svg',
-                        anchor: new Microsoft.Maps.Point(12, 12),
-                        color: BingMapsService.colors[4]
-                    });
-
-                this.map.entities.push(pushpin);
-                this.map.entities.push(polygon);
-
-                subject.next(currentCenter);
-            };
-
-            this.drawHandlerId = Microsoft.Maps.Events.addHandler(this.map, 'click', e => {
-                const event = e as Microsoft.Maps.IMouseEventArgs;
-
-                currentCenter.latitude = event.location.latitude;
-                currentCenter.longitude = event.location.longitude;
-
-                onCircularGeofenceChanged();
-            });
-            const currentDrawHandlerId = this.drawHandlerId;
-            radius
-                .takeWhile(() => currentDrawHandlerId === this.drawHandlerId)
-                .subscribe(r => {
-                    currentRadius = r;
-                    if (currentCenter && currentCenter.latitude && currentCenter.longitude) {
-                        onCircularGeofenceChanged();
-                    }
-                });
-        });
-    }
-
-    drawPolygonGeofence(subject: Subject<Point[]>, initialPoints: Point[]) {
-        this.load().then(() => {
-            let polygonPoints = new Array<Point>();
-            const locationsArray = new Array<Microsoft.Maps.Location>();
-            this.clear();
-
-            if (initialPoints && initialPoints.length > 1) {
-                polygonPoints = initialPoints.slice(0);
-                initialPoints.forEach(p => {
-                    const loc = new Microsoft.Maps.Location(p.latitude, p.longitude);
-                    locationsArray.push(loc);
-                });
-
-                const polygon = new Microsoft.Maps.Polygon(locationsArray, {
-                    fillColor: 'rgba(86,182,145,0.4)',
-                    strokeColor: BingMapsService.colors[0]
-                });
-                this.map.entities.push(polygon);
-                this.centerMapCentroid(initialPoints);
-            }
-
-            this.drawHandlerId = Microsoft.Maps.Events.addHandler(this.map, 'click', e => {
-                const event = e as Microsoft.Maps.IMouseEventArgs;
-                locationsArray.push(event.location);
-
-                const p = new Point();
-                p.latitude = event.location.latitude;
-                p.longitude = event.location.longitude;
-
-                polygonPoints.push(p);
-
-                this.clear();
-                if (locationsArray.length > 1) {
-                    const polygon = new Microsoft.Maps.Polygon(
-                        locationsArray.slice(0),
-                        {
-                            fillColor: 'rgba(233,87,148,0.4)',
-                            strokeColor: BingMapsService.colors[4]
-                        }
-                    );
-                    this.map.entities.push(polygon);
-                } else {
-                    const pushpin = new Microsoft.Maps.Pushpin(event.location, {
-                        color: BingMapsService.colors[4]
-                    });
-                    this.map.entities.push(pushpin);
-                }
-
-                subject.next(polygonPoints);
-            }
-            );
-        });
-    }
-
-    endDraw(): void {
-        this.load().then(() => {
-            if (this.drawHandlerId) {
-                Microsoft.Maps.Events.removeHandler(this.drawHandlerId);
-            }
-        });
-    }
-
-    addLocationPin(subject: Subject<Location>) {
-        this.load().then(() => {
-            this.drawHandlerId = Microsoft.Maps.Events.addHandler(
-                this.map,
-                'click',
-                e => {
-                    const loc = this.addPinInEventHandler(
-                        'location-pin.png',
-                        'New Location',
-                        true,
-                        e
-                    );
-                    this.searchManager.reverseGeocode({
-                        location: new Microsoft.Maps.Location(loc.latitude, loc.longitude),
-                        callback: (placeResult: Microsoft.Maps.Search.IPlaceResult) => {
-                            loc.address = placeResult.address.formattedAddress;
-                            subject.next(loc);
-                        }
-                    });
-                }
-            );
-        });
-    }
-
-    addRoutePins(subject: Subject<Location[]>, initialLocations: Location[]) {
-        this.load().then(() => {
-            let routePoints = new Array<Location>();
-            this.clear();
-
-            if (initialLocations) {
-                routePoints = initialLocations;
-                this.showDispatchingPinsWithOrder(initialLocations);
-            }
-
-            this.drawHandlerId = Microsoft.Maps.Events.addHandler(
-                this.map,
-                'click',
-                e => {
-                    const loc = this.addPinInEventHandler(
-                        'location-pin.png',
-                        'Pin' + '(' + (routePoints.length + 1) + ')',
-                        false,
-                        e
-                    );
-                    loc.name = 'Pin';
-                    routePoints.push(loc);
-
-                    subject.next(routePoints);
-                }
-            );
-        });
-    }
-
-    showDispatchingRoute(
-        points: Point[],
-        clearMap: boolean,
-        colorIndex: number
-    ): void {
-        this.load().then(() => {
-            if (clearMap) {
-                this.clear();
-            }
-
-            if (points) {
-                const locations = [];
-
-                for (const p of points) {
-                    locations.push(new Microsoft.Maps.Location(p.latitude, p.longitude));
-                }
-
-                const polyline = new Microsoft.Maps.Polyline(locations, {
-                    strokeColor:
-                        BingMapsService.tripColors[colorIndex % BingMapsService.tripColors.length],
-                    strokeThickness: 2
-                });
-
-                this.map.entities.push(polyline);
-                this.centerMap(points);
-            }
-        });
-    }
-
-    showDispatchingRoutePins(locations: Location[]) {
-        this.load().then(() => {
-            this.showDispatchingPinsWithOrder(locations);
-        });
-    }
-
-    showPoints(points: Point[]): void {
-        this.load().then(() => {
-            this.clear();
-
-            for (const p of points) {
-                const location = new Microsoft.Maps.Location(p.latitude, p.longitude);
-                const pushpin = new Microsoft.Maps.Pushpin(location, {
-                    color: BingMapsService.colors[4]
-                });
-
-                this.map.entities.push(pushpin);
-            }
-
-            this.centerMap(points);
-        });
-    }
-
-    zoomToPositionAndHighlight(position: Point, zoomLevel: number): void {
-        this.load().then(() => {
-            if (this.previousHighlightPoint) {
-                this.map.entities.remove(this.previousHighlightPoint);
-            }
-
-            this.previousHighlightPoint = this.createPushPin(
-                position,
-                null,
-                BingMapsService.colors[4]
-            );
-            this.map.entities.push(this.previousHighlightPoint);
-            this.zoomToPosition(position, zoomLevel);
-        });
-    }
-
-    zoomToPosition(position: Point, zoomLevel: number): void {
-        this.load().then(() => {
-            const points = [position];
-            this.centerMap(points);
-            this.map.setView({
-                zoom: zoomLevel
-            });
-        });
-    }
-
-    showLocations(
-        positions: Map<string, Location>,
-        icon: string,
-        centerMap: boolean
-    ): void {
-        this.load().then(() => {
-            this.clear();
-
-            const points = [];
-            const positionsArray = Array.from(positions.entries());
-
-            for (const key in positionsArray) {
-                if (positionsArray.hasOwnProperty(key)) {
-                    const loc = positionsArray[key][1];
-                    points.push(this.getLocationPoint(loc));
-                    const location = new Microsoft.Maps.Location(
-                        loc.latitude,
-                        loc.longitude
-                    );
-                    const pushpin = new Microsoft.Maps.Pushpin(location, {
-                        title: positionsArray[key][0],
-                        subTitle: loc.address,
-                        icon: icon
-                    });
-
-                    this.map.entities.push(pushpin);
-                }
-            }
-
-            if (centerMap) {
-                this.centerMap(points);
-                this.map.setView({ zoom: 10 });
-            }
-        });
-    }
-
-    showAssets(positions: [Asset, TrackingPoint][], centerMap: boolean): void {
-        this.load().then(() => {
-            this.clear();
-
-            const points = [];
-
-            for (const position of positions) {
-                const p = position[1];
-                if (p != null) {
-
-                    points.push(p);
-                    const location = new Microsoft.Maps.Location(p.latitude, p.longitude);
-                    const pushpin = new Microsoft.Maps.Pushpin(location, {
-                        title: position[0].id,
-                        subTitle: this.timeConverter(p.time),
-                        icon:
-                            (position[0].assetType === AssetType.Car
-                                ? '/assets/images/car-side.png'
-                                : '/assets/images/truck-side.png')
-                    });
-                    this.map.entities.push(pushpin);
-                }
-            }
-
-            if (centerMap) {
-                this.centerMap(points);
-            }
-        });
-    }
-
-    showDevices(positions: Map<string, TrackingPoint>, centerMap: boolean): void {
-        this.load().then(() => {
-            this.clear();
-
-            const points = [];
-
-            positions.forEach((value, key) => {
-                if (value != null) {
-                    points.push(value);
-                    const location = new Microsoft.Maps.Location(
-                        value.latitude,
-                        value.longitude
-                    );
-                    const pushpin = new Microsoft.Maps.Pushpin(location, {
-                        title: key,
-                        subTitle: this.timeConverter(value.time),
-                        icon: '/assets/images/phone.png'
-                    });
-                    this.map.entities.push(pushpin);
-                }
-
-            });
-
-            if (centerMap) {
-                this.centerMap(points);
-            }
-        });
-    }
-
-    showTrips(trips: Trip[]): void {
-        this.trip = null;
-        this.load().then(() => {
-            this.clear();
-            let colorIndex = 0;
-
-            const tripsLocations = [];
-
-            for (const trip of trips) {
-                this.showTrip(
-                    trip,
-                    false,
-                    BingMapsService.tripColors[colorIndex % BingMapsService.tripColors.length]
-                );
-
-                if (
-                    !tripsLocations.find(
-                        location => location.id === trip.startLocation.id
-                    )
-                ) {
-                    tripsLocations.push(trip.startLocation);
-                }
-
-                if (
-                    !tripsLocations.find(location => location.id === trip.endLocation.id)
-                ) {
-                    tripsLocations.push(trip.endLocation);
-                }
-                colorIndex++;
-            }
-
-            for (const location of tripsLocations) {
-                this.showLocation(
-                    location,
-                    'location-pin.png',
-                    this.locationService.generateLocationName(location)
-                );
-            }
-        });
-    }
-
-    showTrip(trip: Trip, singleTrip?: boolean, color?: string): void {
-        this.load().then(() => {
-            color = color || BingMapsService.colors[4];
-
-            if (singleTrip) {
-                this.clear();
-                this.trip = trip;
-            }
-
-            // Create an infobox at the center of the map but don't show it.
-            this.infobox = new Microsoft.Maps.Infobox(this.map.getCenter(), {
-                visible: false
-            });
-
-            this.infobox.setMap(this.map);
-            let prevEndPoint;
-            let index = 1;
-
-            const tripLegLocations = [];
-
-            for (const leg of trip.tripLegs) {
-                const array = [];
-
-                // Put leg start stop point
-                if (leg.route.length) {
-                    const startPoint = this.createPushPin(
-                        leg.route[0],
-                        trip.id,
-                        BingMapsService.colors[2],
-                        index++
-                    );
-
-                    if (singleTrip) {
-                        this.map.entities.push(startPoint);
-                    }
-
-                    // Draw a dotted line between the previous end point and this one.
-                    if (prevEndPoint) {
-                        const dottedLine = new Microsoft.Maps.Polyline(
-                            [prevEndPoint.getLocation(), startPoint.getLocation()],
-                            {
-                                strokeThickness: 5,
-                                strokeDashArray: [2, 2],
-                                strokeColor: color
-                            }
-                        );
-                        this.map.entities.add(dottedLine);
-                    }
-                }
-
-                for (let i = 0; i < leg.route.length; i++) {
-                    const pushpin = this.createPushPin(leg.route[i], trip.id, color);
-                    array.push(pushpin.getLocation());
-                }
-
-                // Put leg end stop point
-                if (leg.route.length) {
-                    prevEndPoint = this.createPushPin(
-                        leg.route[leg.route.length - 1],
-                        trip.id,
-                        BingMapsService.colors[2],
-                        index++
-                    );
-
-                    if (singleTrip) {
-                        this.map.entities.push(prevEndPoint);
-
-                        if (
-                            !tripLegLocations.find(
-                                location => location.id === leg.startLocation.id
-                            )
-                        ) {
-                            tripLegLocations.push(leg.startLocation);
-                        }
-
-                        if (
-                            !tripLegLocations.find(
-                                location => location.id === leg.endLocation.id
-                            )
-                        ) {
-                            tripLegLocations.push(leg.endLocation);
-                        }
-                    }
-                }
-
-                const line = new Microsoft.Maps.Polyline(array, {
-                    strokeThickness: 5,
-                    strokeColor: color
-                });
-
-                this.map.entities.add(line);
-
-                this.centerMap(array);
-            }
-
-            if (singleTrip) {
-                for (const location of tripLegLocations) {
-                    this.showLocation(
-                        location,
-                        'location-pin.png',
-                        this.locationService.generateLocationName(location)
-                    );
-                }
-            }
-        });
-    }
-
-    geocodeAddress(address: string): Subject<Point> {
-        const subject = new Subject<Point>();
-        this.load().then(() => {
-            this.searchManager.geocode({
-                where: address,
-                count: 1,
-                callback: (geocodeResult: Microsoft.Maps.Search.IGeocodeResult) => {
-                    const res = geocodeResult.results[0];
-                    const p = new Point();
-                    p.latitude = res.location.latitude;
-                    p.longitude = res.location.longitude;
-                    subject.next(p);
-                }
-            });
-        });
-        return subject;
-    }
-    private createPushPin(
-        point: Point,
-        tripId: number,
-        color: string,
-        title?: any,
-        subTitle?: any
-    ) {
-        const location = new Microsoft.Maps.Location(
-            point.latitude,
-            point.longitude
-        );
-        const pushpin = new Microsoft.Maps.Pushpin(location, {
-            color: color,
-            title: title ? title.toString() : '',
-            subTitle: subTitle ? subTitle.toString() : ''
-        });
-
-        pushpin.metadata = {
-            title: 'Pin ',
-            tripId: tripId,
-            point: point
-        };
-
-        return pushpin;
-    }
-
-    private addPinInEventHandler(
-        icon: string,
-        title: string,
-        clearMap: boolean,
-        e: any
-    ): Location {
-        const event = e as Microsoft.Maps.IMouseEventArgs;
-        const loc = new Location();
-        loc.latitude = event.location.latitude;
-        loc.longitude = event.location.longitude;
-        loc.name = title;
-
-        const pushpin = new Microsoft.Maps.Pushpin(event.location, {
-            icon: icon,
-            title: title
-        });
-
-        if (clearMap) {
-            this.clear();
+    endCurrentDraw(): void {
+        if (this.drawHandlerId) {
+            Microsoft.Maps.Events.removeHandler(this.drawHandlerId);
+            this.drawHandlerId = null;
         }
+    }
 
-        this.map.entities.push(pushpin);
-        return loc;
+    centerMap(point: Point, zoom = null) {
+        if (point) {
+            this.map.setView({
+                center: new Microsoft.Maps.Location(
+                    point.latitude,
+                    point.longitude
+                ),
+                zoom: zoom
+            });
+        }
     }
 
     private load(): Promise<void> {
@@ -712,7 +115,7 @@ export class BingMapsService {
         return this.loadPromise;
     }
 
-    private centerMap(points: Point[]) {
+    private centerMapOnMedian(points: Point[]) {
         if (points.length) {
             points.sort(function (x, y) {
                 return x.longitude - y.longitude;
@@ -727,7 +130,7 @@ export class BingMapsService {
         }
     }
 
-    private centerMapCentroid(points: Point[]) {
+    private centerMapOnMean(points: Point[]) {
         if (points.length) {
             let centerLat = 0;
             let centerLong = 0;
@@ -746,46 +149,6 @@ export class BingMapsService {
                 )
             });
         }
-    }
-
-    private getLocationPoint(location: Location): Point {
-        const p = new Point();
-        p.latitude = location.latitude;
-        p.longitude = location.longitude;
-        return p;
-    }
-
-    private showLocation(
-        endPointLocation: Location,
-        icon = 'location-pin.png',
-        locationName: string
-    ): void {
-        this.load().then(() => {
-            const location = new Microsoft.Maps.Location(
-                endPointLocation.latitude,
-                endPointLocation.longitude
-            );
-            const pushpin = new Microsoft.Maps.Pushpin(location, {
-                title: locationName,
-                icon: icon
-            });
-
-            this.map.entities.push(pushpin);
-        });
-    }
-
-    private showDispatchingPinsWithOrder(pins: Location[]) {
-        let index = 1;
-        pins.forEach(location =>
-            this.showLocation(
-                location,
-                'location-pin.png',
-                this.locationService.generateLocationName(location) +
-                ' (' +
-                index++ +
-                ')'
-            )
-        );
     }
 
     private timeConverter(timestamp) {
@@ -813,12 +176,135 @@ export class BingMapsService {
         return `${day} ${month} ${hour}:${min}:${sec}`;
     }
 
-    private clear() {
-        this.trip = null;
-        this.map.entities.clear();
+    private resetMap() {
+        this.geofencesLayer.setVisible(false);
+        this.assetsLayer.setVisible(false);
+        this.devicesLayer.setVisible(false);
+        this.pointsLayer.setVisible(false);
+        this.tripsLayer.setVisible(false);
+        this.locationsLayer.setVisible(false);
+    }
+    /* END GENERIC FUNCTIONS */
+
+    /* GEOFENCES FUNCTIONS */
+    showGeofences(geofences: Geofence[]): void {
+        this.load().then(() => {
+            this.resetMap();
+            this.assetsLayer.setVisible(true);
+            this.geofencesLayer.setVisible(true);
+            this.geofencesLayer.clear();
+
+            let lastGeofencePolygon;
+            for (const geofence of geofences) {
+                lastGeofencePolygon = this.showGeofencePolygon(geofence, this.geofenceGreenBlue, this.genericColors[0]);
+            }
+
+            this.centerMapOnMean(lastGeofencePolygon);
+        });
     }
 
-    private drawGeofencePolygon(geofence: Geofence, fillColor, strokeColor): Microsoft.Maps.Location[] {
+    showGeofence(geofence: Geofence): void {
+        this.load().then(() => {
+            this.resetMap();
+            this.assetsLayer.setVisible(true);
+            this.geofencesLayer.setVisible(true);
+            this.geofencesLayer.clear();
+
+            const polygonLocations = this.showGeofencePolygon(geofence, this.geofenceGreenBlue, this.genericColors[0]);
+
+            this.centerMapOnMean(polygonLocations);
+        });
+    }
+
+    drawCircularGeofence(subject: Subject<Point>, initialCenter: Point, initialRadius: number, radius: Observable<number>) {
+        this.load().then(() => {
+            const tempGeofence = new Geofence();
+            tempGeofence.fenceCenter = initialCenter || new Point();
+            tempGeofence.radiusInMeters = initialRadius || 1;
+            tempGeofence.areaType = AreaType.Circular;
+
+            this.resetMap();
+            this.geofencesLayer.setVisible(true);
+            this.geofencesLayer.clear();
+
+            // Draw initial geofence area value if it exists
+            if (initialCenter && initialCenter.latitude && initialCenter.longitude && initialRadius) {
+                this.showGeofencePolygon(tempGeofence, this.geofenceGreenBlue, this.genericColors[0]);
+            }
+
+            // If new center set, update temp geofence and redraw
+            this.drawHandlerId = Microsoft.Maps.Events.addHandler(this.map, 'click', e => {
+                const event = e as Microsoft.Maps.IMouseEventArgs;
+
+                tempGeofence.fenceCenter.latitude = event.location.latitude;
+                tempGeofence.fenceCenter.longitude = event.location.longitude;
+
+                this.geofencesLayer.clear();
+                this.showGeofencePolygon(
+                    tempGeofence, this.geofencePink, this.genericColors[4], '/assets/images/circular-geofence-center-pink.svg');
+
+                subject.next(tempGeofence.fenceCenter);
+            });
+
+            // If radius changed, update temp geofence and redraw if center is specified
+            // Stop subscribing to updates if the drawHandler is changed
+            const currentDrawHandlerId = this.drawHandlerId;
+            radius
+                .takeWhile(() => currentDrawHandlerId === this.drawHandlerId)
+                .subscribe(r => {
+                    tempGeofence.radiusInMeters = r;
+                    if (tempGeofence.fenceCenter && tempGeofence.fenceCenter.latitude && tempGeofence.fenceCenter.longitude) {
+                        this.geofencesLayer.clear();
+                        this.showGeofencePolygon(
+                            tempGeofence, this.geofencePink, this.genericColors[4], '/assets/images/circular-geofence-center-pink.svg');
+                    }
+                });
+        });
+    }
+
+    drawPolygonGeofence(subject: Subject<Point[]>, initialPoints: Point[]) {
+        this.load().then(() => {
+            const tempGeofence = new Geofence();
+            tempGeofence.fencePolygon = initialPoints || new Array<Point>();
+            tempGeofence.areaType = AreaType.Polygon;
+
+            this.resetMap();
+            this.geofencesLayer.setVisible(true);
+            this.geofencesLayer.clear();
+
+            // Draw initial geofence area value if it exists
+            if (initialPoints && initialPoints.length > 1) {
+                this.showGeofencePolygon(tempGeofence, this.geofenceGreenBlue, this.genericColors[0]);
+            }
+
+            // If new point added, update temp geofence and redraw
+            this.drawHandlerId = Microsoft.Maps.Events.addHandler(this.map, 'click', e => {
+                const event = e as Microsoft.Maps.IMouseEventArgs;
+                tempGeofence.fencePolygon.push(event.location);
+
+                this.geofencesLayer.clear();
+                if (tempGeofence.fencePolygon.length > 1) {
+                    this.showGeofencePolygon(tempGeofence, this.geofencePink, this.genericColors[4]);
+                } else {
+                    const pushpin = new Microsoft.Maps.Pushpin(event.location, {
+                        color: this.genericColors[4]
+                    });
+                    this.map.entities.push(pushpin);
+                }
+
+                subject.next(tempGeofence.fencePolygon);
+            }
+            );
+        });
+    }
+
+    private showGeofencePolygon(
+        geofence: Geofence,
+        fillColor,
+        strokeColor,
+        circularIcon = '/assets/images/circular-geofence-center-green.svg')
+        : Microsoft.Maps.Location[] {
+
         let locations = new Array<Microsoft.Maps.Location>();
 
         if (geofence.areaType === AreaType.Polygon) {
@@ -833,10 +319,10 @@ export class BingMapsService {
                 new Microsoft.Maps.Location(geofence.fenceCenter.latitude, geofence.fenceCenter.longitude),
                 {
                     color: strokeColor,
-                    icon: '/assets/images/circular-geofence-center-green.svg',
+                    icon: circularIcon,
                     anchor: new Microsoft.Maps.Point(12, 12)
                 });
-            this.map.entities.push(pushpin);
+            this.geofencesLayer.add(pushpin);
         }
 
         const polygon = new Microsoft.Maps.Polygon(locations,
@@ -845,7 +331,7 @@ export class BingMapsService {
                 strokeColor: strokeColor
             });
 
-        this.map.entities.push(polygon);
+        this.geofencesLayer.add(polygon);
 
         return locations;
     }
@@ -882,4 +368,453 @@ export class BingMapsService {
 
         return locs;
     }
+    /* END GEOFENCES FUNCTIONS */
+
+    /* LOCATION FUNCTIONS */
+    drawLocationPin(subject: Subject<Location>) {
+        this.load().then(() => {
+            const tempLocation = new Location();
+            tempLocation.name = 'New Location';
+
+            this.resetMap();
+            this.locationsLayer.setVisible(true);
+            this.locationsLayer.clear();
+
+            this.drawHandlerId = Microsoft.Maps.Events.addHandler(this.map, 'click', e => {
+                const event = e as Microsoft.Maps.IMouseEventArgs;
+                tempLocation.latitude = event.location.latitude;
+                tempLocation.longitude = event.location.longitude;
+                this.locationsLayer.clear();
+                this.showLocation(tempLocation);
+
+                this.searchManager.reverseGeocode({
+                    location: event.location,
+                    callback: (placeResult: Microsoft.Maps.Search.IPlaceResult) => {
+                        tempLocation.address = placeResult.address.formattedAddress;
+                        this.locationsLayer.clear();
+                        this.showLocation(tempLocation);
+                        subject.next(tempLocation);
+                    }
+                });
+            }
+            );
+        });
+    }
+
+    drawDispatchingRoute(subject: Subject<Location[]>, initialLocations: Location[]) {
+        this.load().then(() => {
+            const tempRoutePoints = initialLocations || new Array<Location>();
+
+            this.resetMap();
+            this.assetsLayer.setVisible(true);
+            this.locationsLayer.setVisible(true);
+            this.locationsLayer.clear();
+
+            if (initialLocations) {
+                this.showDispatchingRoutePins(tempRoutePoints);
+            }
+
+            this.drawHandlerId = Microsoft.Maps.Events.addHandler(this.map, 'click', e => {
+                const event = e as Microsoft.Maps.IMouseEventArgs;
+
+                const newLocation = new Location();
+                newLocation.name = 'Pin' + '(' + (tempRoutePoints.length + 1) + ')';
+                newLocation.latitude = event.location.latitude;
+                newLocation.longitude = event.location.longitude;
+
+                this.showLocation(newLocation);
+                tempRoutePoints.push(newLocation);
+                subject.next(tempRoutePoints);
+            }
+            );
+        });
+    }
+
+    showDispatchingRoute(points: Point[], clearMap: boolean, colorIndex: number): void {
+        this.load().then(() => {
+            if (clearMap) {
+                this.locationsLayer.clear();
+            }
+
+            if (points && points.length >= 1) {
+                const locations = [];
+
+                for (const p of points) {
+                    locations.push(new Microsoft.Maps.Location(p.latitude, p.longitude));
+                }
+
+                const polyline = new Microsoft.Maps.Polyline(locations, {
+                    strokeColor:
+                        this.tripColors[colorIndex % this.tripColors.length],
+                    strokeThickness: 2
+                });
+
+                this.map.entities.push(polyline);
+                this.centerMap(points[0]);
+            }
+        });
+    }
+
+    showDispatchingRoutePins(locations: Location[]) {
+        this.load().then(() => {
+            this.resetMap();
+            this.locationsLayer.setVisible(true);
+            this.locationsLayer.clear();
+
+            let index = 1;
+            locations.forEach(location => {
+                location.name = this.getNormalizedLocationName(location) + ' (' + index++ + ')';
+                this.showLocation(location);
+            });
+        });
+    }
+
+    showLocations(locations: Location[]) {
+        this.load().then(() => {
+            this.resetMap();
+            this.assetsLayer.setVisible(true);
+            this.locationsLayer.setVisible(true);
+            this.locationsLayer.clear();
+
+            locations.forEach(location => {
+                this.showLocation(location);
+            });
+
+            this.centerMapOnMedian(locations);
+        });
+    }
+
+    geocodeAddress(address: string): Subject<Point> {
+        const subject = new Subject<Point>();
+        this.load().then(() => {
+            this.searchManager.geocode({
+                where: address,
+                count: 1,
+                callback: (geocodeResult: Microsoft.Maps.Search.IGeocodeResult) => {
+                    const res = geocodeResult.results[0];
+                    const p = new Point();
+                    p.latitude = res.location.latitude;
+                    p.longitude = res.location.longitude;
+                    subject.next(p);
+                }
+            });
+        });
+        return subject;
+    }
+
+    private showLocation(location: Location, icon = '/assets/images/location-pin.png') {
+        const mapLocation = new Microsoft.Maps.Location(
+            location.latitude,
+            location.longitude
+        );
+        const pushpin = new Microsoft.Maps.Pushpin(mapLocation, {
+            title: location.name,
+            subTitle: location.address,
+            icon: icon
+        });
+
+        this.locationsLayer.add(pushpin);
+    }
+
+    private getNormalizedLocationName(location: Location) {
+        if (location.name === 'Auto-Generated Location') {
+            return 'Location ' + location.id;
+        } else {
+            return location.name;
+        }
+    }
+    /* END LOCATION FUNCTIONS */
+
+    /* POINT FUNCTIONS */
+    showPoints(points: Point[]): void {
+        this.load().then(() => {
+            this.resetMap();
+            this.pointsLayer.setVisible(true);
+            this.pointsLayer.clear();
+
+            points.forEach(p => this.showPoint(p, this.genericColors[4]));
+
+            this.centerMapOnMedian(points);
+        });
+    }
+
+    private showPoint(point: Point, color) {
+        const location = new Microsoft.Maps.Location(point.latitude, point.longitude);
+        const pushpin = new Microsoft.Maps.Pushpin(location, {
+            color: color
+            //  BingMapsService.colors[4]
+        });
+
+        this.pointsLayer.add(pushpin);
+    }
+    /* END POINT FUNCTIONS */
+
+    /* ASSET FUNCTIONS */
+    showAssets(positions: [Asset, TrackingPoint][], centerMap: boolean): void {
+        this.load().then(() => {
+            if (centerMap) {
+                this.resetMap();
+                this.assetsLayer.setVisible(true);
+            }
+            this.assetsLayer.clear();
+
+            const points = [];
+
+            for (const position of positions) {
+                const p = position[1];
+                if (p != null) {
+
+                    points.push(p);
+                    const location = new Microsoft.Maps.Location(p.latitude, p.longitude);
+                    const pushpin = new Microsoft.Maps.Pushpin(location, {
+                        title: position[0].id,
+                        subTitle: this.timeConverter(p.time),
+                        icon:
+                            (position[0].assetType === AssetType.Car
+                                ? '/assets/images/car-side.png'
+                                : '/assets/images/truck-side.png')
+                    });
+                    this.assetsLayer.add(pushpin);
+                }
+            }
+
+            if (centerMap) {
+                this.centerMapOnMedian(points);
+            }
+        });
+    }
+    /* END ASSET FUNCTIONS */
+
+    /* DEVICE FUNCTIONS */
+    showDevices(positions: Map<string, TrackingPoint>, centerMap: boolean): void {
+        this.load().then(() => {
+            if (centerMap) {
+                this.resetMap();
+                this.devicesLayer.setVisible(true);
+            }
+            this.devicesLayer.clear();
+
+            const points = [];
+
+            positions.forEach((value, key) => {
+                if (value != null) {
+                    points.push(value);
+                    const location = new Microsoft.Maps.Location(
+                        value.latitude,
+                        value.longitude
+                    );
+                    const pushpin = new Microsoft.Maps.Pushpin(location, {
+                        title: key,
+                        subTitle: this.timeConverter(value.time),
+                        icon: '/assets/images/phone.png'
+                    });
+                    this.devicesLayer.add(pushpin);
+                }
+
+            });
+
+            if (centerMap) {
+                this.centerMapOnMedian(points);
+            }
+        });
+    }
+    /* END DEVICE FUNCTIONS */
+
+    /* TRIP FUNCTIONS*/
+    showTrips(trips: Trip[]): void {
+        this.load().then(() => {
+            this.resetMap();
+            this.tripsLayer.setVisible(true);
+            this.tripsLayer.clear();
+
+            let colorIndex = 0;
+            for (const trip of trips) {
+                this.showSimplifiedTrip(trip, this.tripColors[colorIndex++ % this.tripColors.length]);
+            }
+        });
+    }
+
+    showTrip(trip: Trip, color?: string): void {
+        this.load().then(() => {
+            this.resetMap();
+            this.tripsLayer.setVisible(true);
+            this.tripsLayer.clear();
+
+            this.showDetailedTrip(trip);
+
+            this.drawHandlerId = Microsoft.Maps.Events.addHandler(this.map, 'click', e => {
+                const event = e as Microsoft.Maps.IMouseEventArgs;
+                this.tripService.getPoints(
+                    trip.id,
+                    event.location.latitude,
+                    event.location.longitude
+                ).subscribe(points => {
+                    for (const point of points) {
+                        let pinColor;
+                        if (point.speed >= this.greenSpeed) {
+                            pinColor = 'green';
+                        } else if (
+                            point.speed < this.greenSpeed &&
+                            point.speed >= this.yellowSpeed
+                        ) {
+                            pinColor = 'yellow';
+                        } else {
+                            pinColor = 'red';
+                        }
+
+                        const location = new Microsoft.Maps.Location(point.latitude, point.longitude);
+                        const pushPin = new Microsoft.Maps.Pushpin(location, {
+                            color: pinColor,
+                            title: this.timeConverter(point.time),
+                            subTitle: `speed: ${Math.round(point.speed * 3.6)} km/hr, accuracy: ${point.accuracy}`
+                        });
+                        this.tripsLayer.add(pushPin);
+                    }
+                });
+            });
+        });
+    }
+
+    private showDetailedTrip(trip: Trip) {
+        let colorIndex = 0;
+        let previousTripLeg: TripLeg;
+        for (const leg of trip.tripLegs) {
+            const tripLegLocations = [];
+
+            // Show the starting stop in a leg if its different from the ending stop of the last
+            if (!previousTripLeg || previousTripLeg.endLocationId !== leg.startLocationId) {
+                this.showTripLocation(leg.startLocation);
+                tripLegLocations.push(new Microsoft.Maps.Location(
+                    leg.startLocation.latitude,
+                    leg.startLocation.longitude
+                ));
+            }
+
+            // Add all route points
+            for (let i = 0; i < leg.route.length; i++) {
+                tripLegLocations.push(new Microsoft.Maps.Location(
+                    leg.route[i].latitude,
+                    leg.route[i].longitude
+                ));
+            }
+
+            // Show the ending stop in a leg
+            this.showTripLocation(leg.endLocation);
+            tripLegLocations.push(new Microsoft.Maps.Location(
+                leg.endLocation.latitude,
+                leg.endLocation.longitude
+            ));
+
+            // Show every leg in a different color
+            const line = new Microsoft.Maps.Polyline(tripLegLocations, {
+                strokeThickness: 5,
+                strokeColor: this.tripColors[colorIndex++ % this.tripColors.length]
+            });
+            this.tripsLayer.add(line);
+
+            previousTripLeg = leg;
+
+            // Draw a dotted line between trip leg stop locations, if they are not the same.
+            if (previousTripLeg && previousTripLeg.endLocationId !== leg.startLocationId) {
+                const startPoint = new Microsoft.Maps.Location(
+                    leg.startLocation.latitude,
+                    leg.startLocation.longitude
+                );
+
+                const previousLocation = new Microsoft.Maps.Location(
+                    previousTripLeg.endLocation.latitude,
+                    previousTripLeg.endLocation.longitude);
+
+                const dottedLine = new Microsoft.Maps.Polyline(
+                    [previousLocation, startPoint],
+                    {
+                        strokeThickness: 5,
+                        strokeDashArray: [2, 2],
+                        strokeColor: this.genericColors[4]
+                    }
+                );
+                this.tripsLayer.add(dottedLine);
+            }
+        }
+
+        this.centerMap(trip.startLocation);
+    }
+
+    private showSimplifiedTrip(trip: Trip, tripColor) {
+        tripColor = tripColor || this.genericColors[4];
+
+        const tripLegLocations = [];
+
+        // Show the first stop in a trip
+        this.showTripLocation(trip.startLocation);
+        tripLegLocations.push(new Microsoft.Maps.Location(
+            trip.startLocation.latitude,
+            trip.startLocation.longitude
+        ));
+
+        let previousTripLeg: TripLeg;
+        for (const leg of trip.tripLegs) {
+            // Add all route points
+            for (let i = 0; i < leg.route.length; i++) {
+                tripLegLocations.push(new Microsoft.Maps.Location(
+                    leg.route[i].latitude,
+                    leg.route[i].longitude
+                ));
+            }
+
+            // Draw a dotted line between trip leg stop locations, if they are not the same.
+            if (previousTripLeg && previousTripLeg.endLocationId !== leg.startLocationId) {
+                const startPoint = new Microsoft.Maps.Location(
+                    leg.startLocation.latitude,
+                    leg.startLocation.longitude
+                );
+
+                const previousLocation = new Microsoft.Maps.Location(
+                    previousTripLeg.endLocation.latitude,
+                    previousTripLeg.endLocation.longitude);
+
+                const dottedLine = new Microsoft.Maps.Polyline(
+                    [previousLocation, startPoint],
+                    {
+                        strokeThickness: 5,
+                        strokeDashArray: [2, 2],
+                        strokeColor: tripColor
+                    }
+                );
+                this.tripsLayer.add(dottedLine);
+            }
+
+            previousTripLeg = leg;
+        }
+
+        // Show the last stop in a trip
+        this.showTripLocation(trip.endLocation);
+        tripLegLocations.push(new Microsoft.Maps.Location(
+            trip.endLocation.latitude,
+            trip.endLocation.longitude
+        ));
+
+        const line = new Microsoft.Maps.Polyline(tripLegLocations, {
+            strokeThickness: 5,
+            strokeColor: tripColor
+        });
+
+        this.tripsLayer.add(line);
+        this.centerMap(tripLegLocations[0]);
+    }
+
+    private showTripLocation(location: Location, icon = '/assets/images/location-pin.png') {
+        const mapLocation = new Microsoft.Maps.Location(
+            location.latitude,
+            location.longitude
+        );
+        const pushpin = new Microsoft.Maps.Pushpin(mapLocation, {
+            title: location.name,
+            subTitle: location.address,
+            icon: icon
+        });
+
+        this.tripsLayer.add(pushpin);
+    }
+    /* END TRIP FUNCTIONS*/
 }

--- a/Frontend/src/app/maps/maps.service.ts
+++ b/Frontend/src/app/maps/maps.service.ts
@@ -20,26 +20,24 @@ export class MapsService {
     private trip = new Subject<Trip>();
     private geofence = new Subject<Geofence>();
     private geofences = new Subject<Geofence[]>();
-    private geofenceDrawEnd = new Subject();
+    private currentDrawEnd = new Subject();
     private geofenceCircularRadiusChange = new Subject<number>();
     private geofenceCircularDraw = new Subject<[Point, number]>();
     private geofenceCircularDrawResult = new BehaviorSubject<Point>(null);
     private geofencePolygonDraw = new Subject<Point[]>();
     private geofencePolygonDrawResult = new BehaviorSubject<Point[]>(new Array<Point>());
-    private assetsPositions = new Subject<[Asset, TrackingPoint][]>();
+    private assetsPositions = new Subject<[{ [key: string]: TrackingPoint }, boolean]>();
     private assetPosition = new Subject<[Asset, TrackingPoint]>();
     private devicesPositions = new Subject<Map<string, TrackingPoint>>();
     private devicePosition = new Subject<[string, TrackingPoint]>();
     private dispatchingPinsDraw = new Subject<Location[]>();
-    private dispatchingPinsDrawEnd = new Subject();
     private dispatchingPinsDrawResult = new BehaviorSubject<Location[]>(new Array<Location>());
     private dispatchingPoints = new Subject<Point[]>();
     private dispatchingAlternativePoints = new Subject<Point[]>();
     private dispatchingPins = new Subject<Location[]>();
-    private locationsPositions = new Subject<Map<string, Location>>();
+    private locationsPositions = new Subject<Location[]>();
     private locationPosition = new Subject<Location>();
     private locationPinDraw = new Subject<Location>();
-    private locationPinDrawEnd = new Subject();
     private locationPinResult = new Subject<Location>();
     private itineraryPoint = new Subject<Point>();
     private locationSearchQuery = new Subject<string>();
@@ -56,7 +54,6 @@ export class MapsService {
     geocodeResult(point: Point) {
         this.locationSearchResult.next(point);
     }
-
 
     showPoints(points: Point[]) {
         this.points.next(points);
@@ -82,12 +79,8 @@ export class MapsService {
         this.geofenceCircularRadiusChange.next(radius);
     }
 
-    endGeofenceDraw() {
-        this.geofenceDrawEnd.next();
-    }
-
-    showAssetsPositions(positions: [Asset, TrackingPoint][]) {
-        this.assetsPositions.next(positions);
+    showAssetsPositions(positions: { [key: string]: TrackingPoint }, inBackground = false) {
+        this.assetsPositions.next([positions, inBackground]);
     }
 
     showAsset(position: [Asset, TrackingPoint]) {
@@ -102,7 +95,7 @@ export class MapsService {
         this.devicePosition.next(position);
     }
 
-    showLocationsPositions(positions: Map<string, Location>) {
+    showLocationsPositions(positions: Location[]) {
         this.locationsPositions.next(positions);
     }
 
@@ -114,8 +107,8 @@ export class MapsService {
         this.locationPinDraw.next();
     }
 
-    endLocationPinDraw() {
-        this.locationPinDrawEnd.next();
+    endCurrentDraw() {
+        this.currentDrawEnd.next();
     }
 
     showTrips(trips: Trip[]) {
@@ -144,10 +137,6 @@ export class MapsService {
         this.dispatchingPinsDrawResult.next([]);
     }
 
-    endDispatchingPinsDraw() {
-        this.dispatchingPinsDrawEnd.next();
-    }
-
     showItineraryPosition(point: Point) {
         this.itineraryPoint.next(point);
     }
@@ -156,7 +145,7 @@ export class MapsService {
         return this.points.asObservable();
     }
 
-    getAssetsPositions(): Observable<[Asset, TrackingPoint][]> {
+    getAssetsPositions(): Observable<[{ [key: string]: TrackingPoint }, boolean]> {
         return this.assetsPositions.asObservable();
     }
 
@@ -172,7 +161,7 @@ export class MapsService {
         return this.devicePosition.asObservable();
     }
 
-    getLocationsPositions(): Observable<Map<string, Location>> {
+    getLocationsPositions(): Observable<Location[]> {
         return this.locationsPositions.asObservable();
     }
 
@@ -192,10 +181,6 @@ export class MapsService {
         return this.locationPinResult;
     }
 
-    getlocationPinDrawEnd(): Observable<{}> {
-        return this.locationPinDrawEnd.asObservable();
-    }
-
     getDispatchingPinsDraw(): Observable<Location[]> {
         return this.dispatchingPinsDraw.asObservable();
     }
@@ -207,11 +192,6 @@ export class MapsService {
     getDispatchingPinsResultSubject(): Subject<Location[]> {
         return this.dispatchingPinsDrawResult;
     }
-
-    getDispatchingPinsDrawEnd(): Observable<{}> {
-        return this.dispatchingPinsDrawEnd.asObservable();
-    }
-
     getDispatchingPoints(): Observable<Point[]> {
         return this.dispatchingPoints.asObservable();
     }
@@ -256,8 +236,8 @@ export class MapsService {
         return this.geofenceCircularDraw.asObservable();
     }
 
-    getGeofenceDrawEnd(): Observable<{}> {
-        return this.geofenceDrawEnd.asObservable();
+    getCurrentDrawEnd(): Observable<{}> {
+        return this.currentDrawEnd.asObservable();
     }
 
     getGeodencePolygonDrawResult(): Observable<Point[]> {
@@ -281,7 +261,7 @@ export class MapsService {
     }
 
     resetDispatchingDraw(initialPoints: Location[] = null) {
-        this.endDispatchingPinsDraw();
+        this.endCurrentDraw();
         this.startDispatchingPinsDraw(initialPoints);
     }
 


### PR DESCRIPTION
Refactor bing-maps.service to be more manageable.
Use Bing Maps layers to display entities, for easy overlaying.
Overlay asset locations on top of geofences, locations, dispatching.